### PR TITLE
Day 6

### DIFF
--- a/AdventOfCode2024.sln
+++ b/AdventOfCode2024.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Day04", "Day04\Day04.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Day05", "Day05\Day05.csproj", "{4C257A08-5A3F-4685-8529-2183CBA2DCB0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Day06", "Day06\Day06.csproj", "{E9E34177-FBE0-4861-A022-030CE5E45EF1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{4C257A08-5A3F-4685-8529-2183CBA2DCB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4C257A08-5A3F-4685-8529-2183CBA2DCB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4C257A08-5A3F-4685-8529-2183CBA2DCB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9E34177-FBE0-4861-A022-030CE5E45EF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9E34177-FBE0-4861-A022-030CE5E45EF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9E34177-FBE0-4861-A022-030CE5E45EF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9E34177-FBE0-4861-A022-030CE5E45EF1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Day05/Program.cs
+++ b/Day05/Program.cs
@@ -103,7 +103,8 @@ static bool IsCorrectlyOrdered(HashSet<Rule> rules, ReadOnlySpan<byte> line, out
     foreach (var numberRange in line.Split((byte)','))
     {
         if (!Utf8Parser.TryParse(line[numberRange], out byte pageNumber, out _))
-            throw new InvalidOperationException($"Failed to parse page number from {Encoding.UTF8.GetString(line[numberRange])}");
+            throw new InvalidOperationException(
+                $"Failed to parse page number from {Encoding.UTF8.GetString(line[numberRange])}");
 
         pageNumbers[i++] = pageNumber;
     }
@@ -143,7 +144,8 @@ static void CorrectOrdering(HashSet<Rule> rules, ReadOnlySpan<byte> pageNumbers,
     while (ordering)
     {
         if (k++ > maxIterations)
-            throw new InvalidOperationException($"Likely infinite loop detected for page numbers: {string.Join(',', pageNumbers.ToArray())}");
+            throw new InvalidOperationException(
+                $"Likely infinite loop detected for page numbers: {string.Join(',', pageNumbers.ToArray())}");
 
         ordering = false;
         for (var i = 0; i < reordered.Length - 1; i++)

--- a/Day06/Day06.csproj
+++ b/Day06/Day06.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="input.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Day06/Program.cs
+++ b/Day06/Program.cs
@@ -64,11 +64,8 @@ guardPositions.Push(guard);
 while (map.TryMove(ref guard))
 {
     map.MarkPath(guard.X, guard.Y);
-    if (!guardHash.Contains(guard.Position))
-    {
-        guardHash.Add(guard.Position);
+    if (guardHash.Add(guard.Position))
         guardPositions.Push(guard);
-    }
 }
 
 var total1 = guardPositions.Count;
@@ -79,8 +76,9 @@ Span<byte> bytes2 = new byte[bytes.Length];
 bytes.CopyTo(bytes2);
 var map2 = new Map(bytes2, lineRanges);
 // it's theoretically possible to hit an obstruction from all 4 sides
-// but with the given input, I still get the correct answer even with `maxTurns = (numObstructions + 1)`
+// but with the given input, I still get the correct answer even with `maxTurns = (numObstructions + 1) / 4`
 var maxTurns = (numObstructions + 1) * 4;
+var loopHash = new HashSet<Guard>(maxTurns);
 var total2 = 0;
 while (guardPositions.TryPop(out var guardPosition) && guardPositions.TryPeek(out var guard2))
 {
@@ -110,7 +108,7 @@ while (guardPositions.TryPop(out var guardPosition) && guardPositions.TryPeek(ou
             attemptedTurns2++;
         }
 
-        if (numTurns > maxTurns)
+        if (!loopHash.Add(guard2))
         {
             isLoop = true;
             //Console.WriteLine($"Loop found at {position.X}, {position.Y}");
@@ -121,6 +119,7 @@ while (guardPositions.TryPop(out var guardPosition) && guardPositions.TryPeek(ou
     if (isLoop)
         total2++;
 
+    loopHash.Clear();
     map2.Set(position.X, position.Y, previous);
 }
 

--- a/Day06/Program.cs
+++ b/Day06/Program.cs
@@ -1,0 +1,157 @@
+﻿var start = TimeProvider.System.GetTimestamp();
+
+bool useExample = false;
+var exampleBytes = """
+....#.....
+.........#
+..........
+..#.......
+.......#..
+..........
+.#..^.....
+........#.
+#.........
+......#...
+"""u8.ToArray().AsSpan();
+
+var bytes = useExample switch
+{
+    true => exampleBytes,
+    _ => File.ReadAllBytes("input.txt").AsSpan()
+};
+
+const byte GuardUp = (byte)'^';
+
+Guard guard = default;
+var i = 0;
+Span<Range> lineRanges = default;
+foreach (var lineRange in MemoryExtensions.Split(bytes, "\r\n"u8))
+{
+    var line = bytes[lineRange];
+    if (line.IsEmpty)
+        break;
+
+    if (i == 0)
+    {
+        var width = line.Length;
+        var height = (int)Math.Ceiling(bytes.Length / (width + 2.0));
+        lineRanges = new Range[height];
+    }
+
+    lineRanges[i] = lineRange;
+
+    var index = line.IndexOf(GuardUp);
+    if (index != -1)
+        guard = new Guard(index, i, Direction.Up);
+
+    i++;
+}
+
+var map = new Map(bytes, lineRanges);
+map.MarkPath(guard.X, guard.Y);
+while (map.TryMove(ref guard))
+{
+    map.MarkPath(guard.X, guard.Y);
+}
+
+var total1 = map.CountVisitedPositions();
+
+var elapsed = TimeProvider.System.GetElapsedTime(start);
+
+Console.WriteLine($"Part 1 answer: {total1}");
+Console.WriteLine($"Processed {bytes.Length:N0} bytes in: {elapsed.TotalMilliseconds:N3} ms");
+
+ref struct Map
+{
+    const byte Obstacle = (byte)'#';
+    const byte Visited = (byte)'X';
+    private readonly Span<byte> _bytes;
+    private readonly ReadOnlySpan<Range> _lineRanges;
+
+    public Map(Span<byte> bytes, ReadOnlySpan<Range> lineRanges)
+    {
+        _bytes = bytes;
+        _lineRanges = lineRanges;
+        Height = lineRanges.Length;
+        Width = bytes[lineRanges[0]].Length;
+    }
+
+    public int Height { get; }
+    public int Width { get; }
+
+    public readonly int CountVisitedPositions()
+    {
+        var total = 0;
+        foreach (var b in _bytes)
+            if (b == Visited)
+                total++;
+
+        return total;
+    }
+
+    public readonly bool IsInBounds(int x, int y)
+        => x >= 0 && x < Width && y >= 0 && y < Height;
+
+    public void MarkPath(int x, int y)
+    {
+        var line = _bytes[_lineRanges[y]];
+        line[x] = Visited;
+    }
+
+    public readonly bool TryMove(ref Guard guard)
+    {
+        var nextX = guard.X + guard.Direction switch
+        {
+            Direction.Left => -1,
+            Direction.Right => 1,
+            _ => 0
+        };
+        var nextY = guard.Y + guard.Direction switch
+        {
+            Direction.Up => -1,
+            Direction.Down => 1,
+            _ => 0
+        };
+
+        if (!TryGet(nextX, nextY, out var result))
+            return false;
+
+        if (result == Obstacle)
+        {
+            guard.Direction = guard.Direction switch
+            {
+                Direction.Up => Direction.Right,
+                Direction.Right => Direction.Down,
+                Direction.Down => Direction.Left,
+                Direction.Left => Direction.Up,
+                _ => throw new InvalidOperationException("Unexpected direction")
+            };
+            return true;
+        }
+
+        guard.X = nextX;
+        guard.Y = nextY;
+        return true;
+    }
+
+    public readonly bool TryGet(int x, int y, out byte result)
+    {
+        result = default;
+        if (!IsInBounds(x, y))
+            return false;
+
+        var line = _bytes[_lineRanges[y]];
+        result = line[x];
+        return true;
+    }
+}
+
+enum Direction
+{
+    Up,
+    Down,
+    Left,
+    Right
+}
+
+record struct Guard(int X, int Y, Direction Direction);

--- a/Day06/Program.cs
+++ b/Day06/Program.cs
@@ -71,7 +71,7 @@ while (map.TryMove(ref guard))
     }
 }
 
-var total1 = map.CountVisitedPositions();
+var total1 = guardPositions.Count;
 
 var attemptedMoves2 = 0L;
 var attemptedTurns2 = 0L;
@@ -163,16 +163,6 @@ ref struct Map
 
     public int Height { get; }
     public int Width { get; }
-
-    public readonly int CountVisitedPositions()
-    {
-        var total = 0;
-        foreach (var b in _bytes)
-            if (b == Visited)
-                total++;
-
-        return total;
-    }
 
     public readonly bool IsInBounds(int x, int y)
         => x >= 0 && x < Width && y >= 0 && y < Height;


### PR DESCRIPTION
https://adventofcode.com/2024/day/6

Day 6 has been an interesting challenge and had the most opportunity for optimization so far.
My initial part 2 solution took more than 10 seconds in debug mode, but 1.4 seconds in release mode, and was brute forcing more than 200 million "moves".
After some iteration, it still has to do a lot of work, but does it in a somewhat smarter way. It only performs around 7 million "moves", and takes ~250 ms in release mode / ~460 ms in debug mode.

- Instead of re-copying the map every time, reset the obstruction to the previous state.
- Instead of replaying from the starting position every time, store guard moves in a stack, allowing beginning movements to be skipped when checking new potential obstructions (instead of replaying from the start every time).
- Instead of looping over every possible position, only loop through the stack of guard positions.
- Use optimized movement logic for part 2:
  - Store copies of bytes in both row- and column-major order
  - This enables taking advantage of Span.IndexOfAny / LastIndexOfAny to search a whole row or column at a time for obstacles and "move" several positions in a line
  - SearchValues<byte> is used to optimize obstacle searches

My loop detection is somewhat of a brute force method that uses a safer upper bound. I still got the right answer when I divided the upper bound by a factor of 16, and it completed in ~45 ms. However, I don't think that's a safe upper bound.

I strongly suspect there's a better approach to detect loops by detecting overlapping vectors instead of brute force.

Edit: Indeed, using a HashSet of previous guard states, it was fairly trivial to optimize loop detection and avoid brute force loop detection. This brings execution time to ~40 ms without having to worry about compromising on the upper bound. And now it only performs ~226,000 moves vs. 7 million and more.