### PR TITLE
Day 6 followup

### DIFF
--- a/Day06/Program.cs
+++ b/Day06/Program.cs
@@ -83,7 +83,7 @@ var total2 = 0;
 while (guardPositions.TryPop(out var guardPosition) && guardPositions.TryPeek(out var guard2))
 {
     var position = guardPosition.Position;
-    if (position.X == guardStart.X && position.Y == guardStart.Y)
+    if (position == guardStart.Position)
         continue;
 
     if (!map2.TryAddObstruction(position.X, position.Y, out var previous))
@@ -91,10 +91,8 @@ while (guardPositions.TryPop(out var guardPosition) && guardPositions.TryPeek(ou
 
     //Console.WriteLine($"Attempting to add obstruction at {position.X}, {position.Y}");
 
-    //guard2 = guardStart; // testing
     var isLoop = false;
     var lastDirection = guard2.Direction;
-    var numTurns = 0;
     while (map2.TryMoveFast(ref guard2))
     {
         attemptedMoves2++;
@@ -104,7 +102,6 @@ while (guardPositions.TryPop(out var guardPosition) && guardPositions.TryPeek(ou
         {
             //Console.WriteLine($"Turned at {guard2.X}, {guard2.Y}, {guard2.Direction} (turn # {numTurns + 1})");
             lastDirection = guard2.Direction;
-            numTurns++;
             attemptedTurns2++;
         }
 
@@ -124,10 +121,6 @@ while (guardPositions.TryPop(out var guardPosition) && guardPositions.TryPeek(ou
 }
 
 var elapsed = TimeProvider.System.GetElapsedTime(start);
-
-var expected = useExample ? 6 : 2162;
-if (total2 != expected)
-    Console.WriteLine($"Wrong answer. Expected: {expected}, Actual: {total2}");
 
 Console.WriteLine($"Part 1 answer: {total1}");
 Console.WriteLine($"Part 2 answer: {total2}");

--- a/Day06/Program.cs
+++ b/Day06/Program.cs
@@ -64,7 +64,7 @@ var elapsed = TimeProvider.System.GetElapsedTime(start);
 
 Console.WriteLine($"Part 1 answer: {total1}");
 Console.WriteLine($"Part 2 answer: {executor2.Total}");
-Console.WriteLine($"Part 2 attempted moves: {executor2.AttemptedMoves:N0}, turns: {executor2.AttemptedTurns:N0}");
+//Console.WriteLine($"Part 2 attempted moves: {executor2.AttemptedMoves:N0}, turns: {executor2.AttemptedTurns:N0}");
 Console.WriteLine($"Part 1 elapsed: {elapsed1.TotalMilliseconds:N3} ms");
 Console.WriteLine($"Processed {bytes.Length:N0} bytes in: {elapsed.TotalMilliseconds:N3} ms");
 
@@ -103,8 +103,8 @@ class ExecutorPart2(MapData mapData, BlockingCollection<GuardMovement> guardMove
             }
         }
 
-        Interlocked.Add(ref _attemptedMoves, attemptedMoves);
-        Interlocked.Add(ref _attemptedTurns, attemptedTurns);
+        //Interlocked.Add(ref _attemptedMoves, attemptedMoves);
+        //Interlocked.Add(ref _attemptedTurns, attemptedTurns);
         Interlocked.Add(ref _total, total);
     }
 
@@ -121,21 +121,21 @@ class ExecutorPart2(MapData mapData, BlockingCollection<GuardMovement> guardMove
         //builder.AppendLine($"Guard position: {guard.X}, {guard.Y}, {guard.Direction}");
 
         var isLoop = false;
-        var lastDirection = guard.Direction;
-        var numTurns = 0;
+        //var lastDirection = guard.Direction;
+        //var numTurns = 0;
         while (map.TryMoveFast(ref guard, in newObstruction))
         {
-            Debug.Assert(guard.X >= 0 && guard.Y >= 0);
-            attemptedMoves++;
+            //Debug.Assert(guard.X >= 0 && guard.Y >= 0);
+            //attemptedMoves++;
 
             //builder.AppendLine($"- Moved to {guard.X}, {guard.Y}");
-            if (guard.Direction != lastDirection)
-            {
-                //builder.AppendLine($"- Turned at {guard.X}, {guard.Y}, {guard.Direction} (turn # {numTurns + 1})");
-                lastDirection = guard.Direction;
-                attemptedTurns++;
-                numTurns++;
-            }
+            //if (guard.Direction != lastDirection)
+            //{
+            //    //builder.AppendLine($"- Turned at {guard.X}, {guard.Y}, {guard.Direction} (turn # {numTurns + 1})");
+            //    lastDirection = guard.Direction;
+            //    attemptedTurns++;
+            //    numTurns++;
+            //}
 
             if (!loopHash.Add(guard))
             {


### PR DESCRIPTION
Follow-up to #5.

This parallelizes the day 6 solution. It reduces execution time from ~40 ms to ~25 ms. One might expect parallelization to result in a greater improvement. However, there are some trade-offs that reduce efficiency when parallelizing.
For example, this adds additional logic to check for the new obstruction instead of mutating underlying map data. It uses a blocking collection to pass guard movements to other threads. And it modifies span/ref struct usage in part because of restrictions and in part as a result of profiling/benchmarking this particular usage.