### PR TITLE
Day 9

### DIFF
--- a/AdventOfCode2024.sln
+++ b/AdventOfCode2024.sln
@@ -20,6 +20,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Day07", "Day07\Day07.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Day08", "Day08\Day08.csproj", "{16775E51-8EF0-47C8-B575-162CA322B94C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Day09", "Day09\Day09.csproj", "{D8AE049C-F959-4432-A3E1-DC5801869720}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{16775E51-8EF0-47C8-B575-162CA322B94C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{16775E51-8EF0-47C8-B575-162CA322B94C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16775E51-8EF0-47C8-B575-162CA322B94C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8AE049C-F959-4432-A3E1-DC5801869720}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8AE049C-F959-4432-A3E1-DC5801869720}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8AE049C-F959-4432-A3E1-DC5801869720}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8AE049C-F959-4432-A3E1-DC5801869720}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Day09/Day09.csproj
+++ b/Day09/Day09.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="input.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Day09/Program.cs
+++ b/Day09/Program.cs
@@ -33,32 +33,28 @@ for (int i = 0, id = 0; i < diskMap.Length; i += 2, id++)
     }
 }
 
-var diskSpan = disk.Span;
-var contiguousLength = CompactFiles(diskSpan);
-var checksum1 = CalculateChecksumContiguous(diskSpan);
+var disk1 = disk.Span.ToArray().AsSpan();
+var contiguousLength1 = CompactFilesFragmenting(disk1);
+var checksum1 = CalculateChecksum(disk1);
+
+var disk2 = disk.Span.ToArray().AsSpan();
+CompactFilesNonFragmenting(disk2);
+var checksum2 = CalculateChecksum(disk2);
 
 var elapsed = TimeProvider.System.GetElapsedTime(start);
 
 Console.WriteLine($"Part 1 checksum: {checksum1}");
+Console.WriteLine($"Part 2 checksum: {checksum2}");
 Console.WriteLine($"Processed {bytes.Length:N0} bytes in: {elapsed.TotalMilliseconds:N3} ms");
 
-static void FormatDisk(StringBuilder builder, ReadOnlySpan<short?> disk)
-{
-    for (var i = 0; i < disk.Length; i++)
-    {
-        var item = disk[i];
-        builder.Append(item.HasValue ? (char)((item.Value % 10) + (byte)'0') : '.');
-    }
-}
-
-static long CalculateChecksumContiguous(Span<short?> disk)
+static long CalculateChecksum(Span<short?> disk)
 {
     var checksum = 0L;
     for (var i = 0; i < disk.Length; i++)
     {
         var id = disk[i];
         if (!id.HasValue)
-            break;
+            continue;
 
         checksum += i * id.Value;
     }
@@ -66,7 +62,7 @@ static long CalculateChecksumContiguous(Span<short?> disk)
     return checksum;
 }
 
-static int CompactFiles(Span<short?> disk)
+static int CompactFilesFragmenting(Span<short?> disk)
 {
     var builder = new StringBuilder(disk.Length);
     var i = 0;
@@ -79,14 +75,14 @@ static int CompactFiles(Span<short?> disk)
             continue;
         }
 
-        var block = disk[j];
-        if (IsFree(block))
+        var fileId = disk[j];
+        if (IsFree(fileId))
         {
             j--;
             continue;
         }
 
-        disk[i++] = block;
+        disk[i++] = fileId;
         disk[j--] = null;
 
         //FormatDisk(builder, disk);
@@ -97,6 +93,98 @@ static int CompactFiles(Span<short?> disk)
     return j + 1;
 }
 
+static void CompactFilesNonFragmenting(Span<short?> disk)
+{
+    var builder = new StringBuilder(disk.Length);
+    var i = 0;
+    var j = disk.Length - 1;
+    while (i < j)
+    {
+        if (!TryGetNextFreeBlock(disk, i, j, out i, out _))
+            break;
+
+        var fileId = disk[j];
+        if (IsFree(fileId))
+        {
+            j--;
+            continue;
+        }
+
+        var fileLength = GetFileLength(disk, j);
+        var fileStart = j - fileLength + 1;
+        j = fileStart - 1;
+        if (TryGetFreeBlock(disk, i, fileStart, fileLength, out var freeStart, out _))
+            MoveFile(disk, fileStart, fileLength, freeStart);
+        else
+            continue;
+
+        //FormatDisk(builder, disk);
+        //Console.WriteLine(builder);
+        //builder.Clear();
+    }
+}
+
+static int GetFileLength(ReadOnlySpan<short?> disk, int end)
+{
+    var id = disk[end];
+    if (IsFree(id))
+        return 0;
+
+    var length = 1;
+    for (var i = end - 1; i >= 0; i--)
+    {
+        if (disk[i] != id)
+            break;
+
+        length++;
+    }
+
+    return length;
+}
+
 static byte GetMapValue(byte utf8Byte) => (byte)(utf8Byte - (byte)'0');
 
 static bool IsFree(short? block) => !block.HasValue;
+
+static void MoveFile(Span<short?> disk, int fileStart, int fileLength, int freeStart)
+{
+    var originalFile = disk.Slice(fileStart, fileLength);
+    originalFile.CopyTo(disk[freeStart..]);
+
+    for (var i = 0; i < fileLength; i++)
+        originalFile[i] = null;
+}
+
+static bool TryGetFreeBlock(
+    ReadOnlySpan<short?> disk, int start, int end, int minSize, out int freeStart, out int freeLength)
+{
+    while (TryGetNextFreeBlock(disk, start, end, out freeStart, out freeLength))
+    {
+        if (freeLength >= minSize)
+            return true;
+
+        start = freeStart + freeLength;
+    }
+
+    freeStart = -1;
+    freeLength = 0;
+    return false;
+}
+
+static bool TryGetNextFreeBlock(ReadOnlySpan<short?> disk, int start, int end, out int freeStart, out int freeLength)
+{
+    freeStart = -1;
+    freeLength = 0;
+    for (var i = start; i < end; i++)
+    {
+        var id = disk[i];
+        if (freeStart == -1 && IsFree(id))
+            freeStart = i;
+        if (IsFree(id))
+            freeLength++;
+        else if (freeStart != -1)
+            break;
+    }
+
+    return freeStart != -1;
+}

--- a/Day09/Program.cs
+++ b/Day09/Program.cs
@@ -123,6 +123,15 @@ static void CompactFilesNonFragmenting(Span<short> disk)
     }
 }
 
+static void FormatDisk(StringBuilder builder, ReadOnlySpan<short> disk)
+{
+    for (var i = 0; i < disk.Length; i++)
+    {
+        var item = disk[i];
+        builder.Append(item >= 0 ? (char)((item % 10) + (byte)'0') : '.');
+    }
+}
+
 static byte GetMapValue(byte utf8Byte) => (byte)(utf8Byte - (byte)'0');
 
 static bool IsFree(short block) => block == Free;

--- a/Day09/Program.cs
+++ b/Day09/Program.cs
@@ -138,6 +138,7 @@ static void MoveFile(Span<short> disk, int fileStart, int fileLength, int freeSt
 
 static bool TryGetFileBlock(ReadOnlySpan<short> disk, int end, out int fileStart, out int fileLength)
 {
+    const int maxLength = 9;
     var id = disk[end];
     if (IsFree(id))
     {
@@ -146,7 +147,8 @@ static bool TryGetFileBlock(ReadOnlySpan<short> disk, int end, out int fileStart
         return false;
     }
 
-    fileStart = disk[..(end + 1)].IndexOf(id);
+    var start = Math.Max(0, end - maxLength);
+    fileStart = start + disk[start..(end + 1)].IndexOf(id);
     fileLength = end - fileStart + 1;
     return true;
 }
@@ -175,7 +177,7 @@ static bool TryGetNextFreeBlock(ReadOnlySpan<short> disk, int start, int end, ou
         return false;
 
     freeLength = 1;
-    freeStart = start + freeStart;
+    freeStart += start;
     for (var i = freeStart + 1; i < end; i++)
     {
         var id = disk[i];

--- a/Day09/Program.cs
+++ b/Day09/Program.cs
@@ -1,0 +1,102 @@
+﻿using System.Text;
+using Core;
+
+var start = TimeProvider.System.GetTimestamp();
+
+int? useExample = null;
+var exampleBytes1 = "2333133121414131402"u8;
+var exampleBytes2 = "12345"u8;
+
+var bytes = useExample switch
+{
+    1 => exampleBytes1,
+    2 => exampleBytes2,
+    _ => File.ReadAllBytes("input.txt").AsSpan()
+};
+
+var diskMap = bytes;
+
+using var disk = new PoolableList<short?>(bytes.Length * 4);
+for (int i = 0, id = 0; i < diskMap.Length; i += 2, id++)
+{
+    // file
+    var fileLength = GetMapValue(diskMap[i]);
+    for (var j = 0; j < fileLength; j++)
+        disk.Add((short)id);
+
+    // free space
+    if (i + 1 < diskMap.Length)
+    {
+        var freeLength = GetMapValue(diskMap[i + 1]);
+        for (var j = 0; j < freeLength; j++)
+            disk.Add(null);
+    }
+}
+
+var diskSpan = disk.Span;
+var contiguousLength = CompactFiles(diskSpan);
+var checksum1 = CalculateChecksumContiguous(diskSpan);
+
+var elapsed = TimeProvider.System.GetElapsedTime(start);
+
+Console.WriteLine($"Part 1 checksum: {checksum1}");
+Console.WriteLine($"Processed {bytes.Length:N0} bytes in: {elapsed.TotalMilliseconds:N3} ms");
+
+static void FormatDisk(StringBuilder builder, ReadOnlySpan<short?> disk)
+{
+    for (var i = 0; i < disk.Length; i++)
+    {
+        var item = disk[i];
+        builder.Append(item.HasValue ? (char)((item.Value % 10) + (byte)'0') : '.');
+    }
+}
+
+static long CalculateChecksumContiguous(Span<short?> disk)
+{
+    var checksum = 0L;
+    for (var i = 0; i < disk.Length; i++)
+    {
+        var id = disk[i];
+        if (!id.HasValue)
+            break;
+
+        checksum += i * id.Value;
+    }
+
+    return checksum;
+}
+
+static int CompactFiles(Span<short?> disk)
+{
+    var builder = new StringBuilder(disk.Length);
+    var i = 0;
+    var j = disk.Length - 1;
+    while (i < j)
+    {
+        if (!IsFree(disk[i]))
+        {
+            i++;
+            continue;
+        }
+
+        var block = disk[j];
+        if (IsFree(block))
+        {
+            j--;
+            continue;
+        }
+
+        disk[i++] = block;
+        disk[j--] = null;
+
+        //FormatDisk(builder, disk);
+        //Console.WriteLine(builder);
+        //builder.Clear();
+    }
+
+    return j + 1;
+}
+
+static byte GetMapValue(byte utf8Byte) => (byte)(utf8Byte - (byte)'0');
+
+static bool IsFree(short? block) => !block.HasValue;


### PR DESCRIPTION
https://adventofcode.com/2024/day/9

This problem totally made me think of watching the [Windows 95 Disk Defragmenter](https://www.youtube.com/watch?v=kPv1gQ5Rs8A&t=37s).

I ran into a few off-by-one errors while working on this one that slowed me down. My initial implementation was approx. 190 ms* and I was able to reduce that to 35 ms*. One of my optimizations was to use non-nullable shorts which allowed using IndexOf which has some vector optimizations. But it's still O(N²).

A further potential optimization for part 2 might be to store a lookup of free blocks by size to avoid having to search for free blocks every time - but it would have to find the leftmost block >= the file size, so it would be trickier than matching by exact size and I'm not sure if it would be a net improvement.

I did include a formatter... but it was only really useful for the examples (* the formatter was omitted from execution times). For the main input it's way too much data to format all the steps, and even the final state takes several screens. I would either have to use pixels or some more compact ascii representation to format the main input.

![image](https://github.com/user-attachments/assets/ef21b39d-2a54-430e-a749-eedc39d65d82)