### PR TITLE
Day 11

### DIFF
--- a/AdventOfCode2024.sln
+++ b/AdventOfCode2024.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Day09", "Day09\Day09.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Day10", "Day10\Day10.csproj", "{772218FA-4CBC-43EA-A9A9-C40F4EEE25B1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Day11", "Day11\Day11.csproj", "{32AAAF70-4760-4A50-B1FB-DCE93E0A99F2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -74,6 +76,10 @@ Global
 		{772218FA-4CBC-43EA-A9A9-C40F4EEE25B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{772218FA-4CBC-43EA-A9A9-C40F4EEE25B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{772218FA-4CBC-43EA-A9A9-C40F4EEE25B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32AAAF70-4760-4A50-B1FB-DCE93E0A99F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32AAAF70-4760-4A50-B1FB-DCE93E0A99F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32AAAF70-4760-4A50-B1FB-DCE93E0A99F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32AAAF70-4760-4A50-B1FB-DCE93E0A99F2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Core/PoolableList.cs
+++ b/Core/PoolableList.cs
@@ -29,9 +29,20 @@ public sealed class PoolableList<T>(int minimumLength = PoolableList<T>.MinLengt
 
     public Span<T> Span => _buffer.AsSpan(0, _length);
 
+    /// <summary>
+    /// Resets length and clears values
+    /// </summary>
     public void Clear()
     {
         _buffer.AsSpan().Clear();
+        _length = 0;
+    }
+
+    /// <summary>
+    /// Resets length without clearing values
+    /// </summary>
+    public void Reset()
+    {
         _length = 0;
     }
 

--- a/Day11/Day11.csproj
+++ b/Day11/Day11.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="input.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Day11/Day11.csproj
+++ b/Day11/Day11.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="input.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Day11/Program.cs
+++ b/Day11/Program.cs
@@ -1,0 +1,154 @@
+﻿using System.Buffers.Text;
+using System.Text;
+
+var start = TimeProvider.System.GetTimestamp();
+
+const int numBlinks = 25;
+int? useExample = null;
+var exampleBytes1 = "0 1 10 99 999"u8.ToArray();
+var exampleBytes2 = "125 17"u8.ToArray();
+
+var bytes = useExample switch
+{
+    1 => exampleBytes1,
+    2 => exampleBytes2,
+    _ => File.ReadAllBytes("input.txt")
+};
+
+var stones = new LinkedList<Stone>();
+foreach (var stoneRange in MemoryExtensions.Split(bytes, (byte)' '))
+{
+    var stoneSpan = bytes.AsSpan(stoneRange);
+    if (Utf8Parser.TryParse(stoneSpan, out int number, out int length))
+    {
+        var stone = new Stone(number, length);
+        stones.AddLast(stone);
+    }
+}
+
+//var stringBuilder = new StringBuilder();
+//Format(stringBuilder, stones);
+//Console.WriteLine(stringBuilder);
+for (var blink = 0; blink < numBlinks; blink++)
+{
+    var node = stones.First;
+    while (node != null)
+    {
+        if (node.Value.Number == 0)
+        {
+            node.ValueRef.Number = 1;
+        }
+        else if (node.Value.Digits.IsEven())
+        {
+            node.Value.Split(out var left, out var right);
+            stones.AddBefore(node, left);
+            node.ValueRef = right;
+        }
+        else
+        {
+            node.ValueRef = node.Value.Multiply2024();
+        }
+
+        node = node.Next;
+    }
+
+    //Format(stringBuilder, stones);
+    //Console.WriteLine(stringBuilder);
+}
+
+var numStones = stones.Count;
+
+var elapsed = TimeProvider.System.GetElapsedTime(start);
+
+Console.WriteLine($"Part 1: Number of stones: {numStones}");
+Console.WriteLine($"Processed {bytes.Length:N0} bytes in: {elapsed.TotalMilliseconds:N3} ms");
+
+static void Format(StringBuilder builder, LinkedList<Stone> stones)
+{
+    builder.Clear();
+    var i = 0;
+    foreach (var stone in stones)
+    {
+        if (i > 0)
+            builder.Append(' ');
+
+        if (builder.Length >= 60)
+        {
+            builder.Append("...");
+            break;
+        }
+
+        builder.Append(stone.Number);
+
+        i++;
+    }
+
+    builder.Append("   <== ");
+    builder.Append(stones.Count);
+    builder.Append(" stones");
+}
+
+record struct Stone(long Number, int Digits)
+{
+    public readonly Stone Multiply2024()
+    {
+        var number = Number * 2024L;
+        var digits = number >= (Digits + 3).Pow10()
+            ? Digits + 4
+            : Digits + 3;
+
+        //Debug.Assert(number >= 0L);
+        //Debug.Assert(digits == $"{number}".Length);
+        return new(number, digits);
+    }
+
+    public readonly void Split(out Stone left, out Stone right)
+    {
+        var digits = Digits / 2;
+        var divisor = digits.Pow10();
+        left = new Stone(Number / divisor, digits);
+
+        var rightNumber = Number % divisor;
+        if (rightNumber < 10)
+        {
+            right = new Stone(rightNumber, 1);
+            return;
+        }
+
+        var rightDigits = digits;
+        while (rightNumber < (rightDigits - 1).Pow10())
+            rightDigits--;
+
+        right = new Stone(rightNumber, rightDigits);
+    }
+}
+
+static class IntegerExtensions
+{
+    static readonly long[] PowersOfTen =
+        [
+            1,
+            10,
+            100,
+            1_000,
+            10_000,
+            100_000,
+            1_000_000,
+            10_000_000,
+            100_000_000,
+            1_000_000_000,
+            10_000_000_000,
+            100_000_000_000,
+            1_000_000_000_000,
+            10_000_000_000_000,
+            100_000_000_000_000,
+            1_000_000_000_000_000,
+            10_000_000_000_000_000,
+            100_000_000_000_000_000,
+            1_000_000_000_000_000_000
+        ];
+
+    public static bool IsEven(this int value) => value == (value >> 1) << 1;
+
+    public static long Pow10(this int exponent) => PowersOfTen[exponent];
+}

--- a/Day11/Program.cs
+++ b/Day11/Program.cs
@@ -3,7 +3,8 @@ using System.Text;
 
 var start = TimeProvider.System.GetTimestamp();
 
-const int numBlinks = 25;
+const int numBlinks1 = 25;
+const int numBlinks2 = 75;
 int? useExample = null;
 var exampleBytes1 = "0 1 10 99 999"u8.ToArray();
 var exampleBytes2 = "125 17"u8.ToArray();
@@ -29,8 +30,11 @@ foreach (var stoneRange in MemoryExtensions.Split(bytes, (byte)' '))
 //var stringBuilder = new StringBuilder();
 //Format(stringBuilder, stones);
 //Console.WriteLine(stringBuilder);
-for (var blink = 0; blink < numBlinks; blink++)
+var numStones1 = 0;
+var numStones2 = 0;
+for (var blink = 1; blink <= Math.Max(numBlinks1, numBlinks2); blink++)
 {
+    var blinkStart = TimeProvider.System.GetTimestamp();
     var node = stones.First;
     while (node != null)
     {
@@ -52,15 +56,23 @@ for (var blink = 0; blink < numBlinks; blink++)
         node = node.Next;
     }
 
+    var numStones = stones.Count;
+    Console.WriteLine($"Blink: {blink}, Stones: {numStones:N0}, Elapsed: {TimeProvider.System.GetElapsedTime(blinkStart)}");
+
+    if (blink == numBlinks1)
+        numStones1 = numStones;
+
+    if (blink == numBlinks2)
+        numStones2 = numStones;
+
     //Format(stringBuilder, stones);
     //Console.WriteLine(stringBuilder);
 }
 
-var numStones = stones.Count;
-
 var elapsed = TimeProvider.System.GetElapsedTime(start);
 
-Console.WriteLine($"Part 1: Number of stones: {numStones}");
+Console.WriteLine($"Part 1: Number of stones: {numStones1}");
+Console.WriteLine($"Part 2: Number of stones: {numStones2}");
 Console.WriteLine($"Processed {bytes.Length:N0} bytes in: {elapsed.TotalMilliseconds:N3} ms");
 
 static void Format(StringBuilder builder, LinkedList<Stone> stones)


### PR DESCRIPTION
https://adventofcode.com/2024/day/11

Day 11 was the first day where my initial attempts blew up so dramatically, resulting in out of memory errors and exponential slowdowns.

![bafkreibli7rsq3og4bv7bosbottloymu5f2tr4tq6tt22osqc3eyzcksqm](https://github.com/user-attachments/assets/954d0f43-af5b-4caf-a065-ce705f864b71 "A screenshot of memory consumption from Task Manager showing 100% usage before dropping drastically to 30%")

It turns out the part 2 solution is unsolvable by storing the full collection of stones. The total is so large that even if only 1 byte per stone were used, it would far exceed any mere mortal's memory (supercomputers are not mortal).

I started by using a LinkedList and adding and mutating nodes, but the system ran out of memory and it exponentially slowed to a crawl. I stopped it around blink 42-43.

I then converted to a pair of PoolableLists, which use rented arrays. This seemed a bit faster, but it ran into the same issue after blink 44, with an explicit Out of Memory error. I suspect it actually reached a 32-bit array limit. I thought about trying to use a series of arrays (but I realize that would have failed as well).

![bafkreiepb7nikty5gnddvknevcuo55wpzsugg5lgxpesosxxnd3musrujm](https://github.com/user-attachments/assets/ffbea87b-eadf-4e96-ab8a-9892e060c85e "Console output showing blinks, stones, and elapsed times for each blink, with the last 5 blinks growing significantly in time. At the end is the message: 'Out of memory.'")

I needed a different approach. Instead of a "breadth-first" approach, I tried a "depth-first" approach using recursion. Instead of storing the full state, I only calculated and summed counts. I ran it, and memory usage was only like 5 MB. However, it ran and ran and it didn't look like it was going to complete any time soon.

Finally, I brought out an old computer science trick: [memoization](https://en.wikipedia.org/wiki/Memoization). I wasn't sure how many possible states there might be, so I had some doubts. But it completed almost instantly, in 40 ms, and it appeared to only use approx. 12 MB.

I even tried blinks up to 1,000, and it still completed in less than a second, though at that point I got a negative total due to overflow.

It turns out I could have better heeded the warning from the line, "The Historians sure are taking a long time. To be fair, the infinite corridors are very large."