### PR TITLE
Day 18

### DIFF
--- a/AdventOfCode2024.slnx
+++ b/AdventOfCode2024.slnx
@@ -17,6 +17,7 @@
   <Project Path="Day15/Day15.csproj" />
   <Project Path="Day16/Day16.csproj" />
   <Project Path="Day17/Day17.csproj" Id="2c66f5db-1825-4518-bd6f-5f817bb804c4" />
+  <Project Path="Day18/Day18.csproj" Id="a32b19a0-ea54-49f4-996e-456d4f6be856" />
   <Project Path="Day19/Day19.csproj" Id="e8d610fe-bd85-4e8d-b71e-b09c93d29a4c" />
   <Project Path="Day22/Day22.csproj" Id="5d17ca95-e276-4c16-b724-417093267f0a" />
   <Project Path="Day23/Day23.csproj" Id="75f54ba6-cf1e-4eeb-993a-c6aff9cd4063" />

--- a/Day18/Day18.csproj
+++ b/Day18/Day18.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="input.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Day18/Program.cs
+++ b/Day18/Program.cs
@@ -1,0 +1,164 @@
+﻿using System.Buffers.Text;
+using Core;
+
+var startTimestamp = TimeProvider.System.GetTimestamp();
+
+int? useExample = null;
+var exampleBytes1 = """
+    5,4
+    4,2
+    4,5
+    3,0
+    2,1
+    6,3
+    2,4
+    1,5
+    0,6
+    3,3
+    2,6
+    5,1
+    1,2
+    5,5
+    2,5
+    6,5
+    1,4
+    0,4
+    6,4
+    1,1
+    6,1
+    1,0
+    0,5
+    1,6
+    2,0
+    """u8.ToArray();
+
+var input = useExample switch
+{
+    1 => (Bytes: exampleBytes1, Height: 7, Width: 7, SimulationBytes: 12),
+    _ => (Bytes: File.ReadAllBytes("input.txt"), Height: 71, Width: 71, SimulationBytes: 1024)
+};
+
+var start = new Position(0, 0);
+var goal = new Position((byte)(input.Width - 1), (byte)(input.Height - 1));
+
+using var fallingBytes = new PoolableList<Position>(input.Bytes.Length / 5);
+var inputBytes = input.Bytes.AsSpan();
+foreach (var range in MemoryExtensions.Split(inputBytes, "\r\n"u8))
+{
+    var line = inputBytes[range];
+    if (line.IsEmpty)
+        continue;
+
+    var separatorIndex = line.IndexOf((byte)',');
+    if (separatorIndex >= 0
+        && Utf8Parser.TryParse(line[..separatorIndex], out byte x, out _)
+        && Utf8Parser.TryParse(line[(separatorIndex + 1)..], out byte y, out _))
+    {
+        fallingBytes.Add(new Position(x, y));
+    }
+}
+
+Span<byte> rows = new byte[input.Width * input.Height];
+rows.Fill((byte)'.');
+var rowOrder = new RowOrderSpan<byte>(rows, input.Width, input.Height);
+var fallingSpan = fallingBytes.Span;
+for (var i = 0; i < input.SimulationBytes; i++)
+{
+    var position = fallingSpan[i];
+    if (rowOrder.TryGetIndex(position.X, position.Y, out var index))
+        rowOrder.Span[index] = (byte)'#';
+}
+
+var total1 = AStar(in rowOrder, in start, in goal);
+
+var elapsed = TimeProvider.System.GetElapsedTime(startTimestamp);
+
+Console.WriteLine($"Part 1: {total1}");
+Console.WriteLine($"Processed {input.Bytes.Length:N0} input bytes in: {elapsed.TotalMilliseconds:N3} ms");
+
+// adapted from https://en.wikipedia.org/wiki/A*_search_algorithm
+static int AStar(in RowOrderSpan<byte> rowOrder, in Position start, in Position goal)
+{
+    var width = rowOrder.Width;
+    var height = rowOrder.Height;
+    var fStart = Heuristic(in start, in goal);
+    rowOrder.TryGetIndex(start.X, start.Y, out var startIndex);
+    var open = new PriorityQueue<MoveNode, int>([(MoveNode.Start(start.X, start.Y), fStart)]);
+
+    // cost of cheapest known path from start to n
+    var gScores = new RowOrderSpan<int>(new int[width * height], width, height);
+    var gSpan = gScores.Span;
+    gSpan.Fill(int.MaxValue);
+    gSpan[startIndex] = 0;
+
+    // currently known cheapest path from start to end through n
+    var fScores = new RowOrderSpan<int>(new int[width * height], width, height);
+    var fSpan = fScores.Span;
+    fSpan.Fill(int.MaxValue);
+    fSpan[startIndex] = fStart;
+
+    Span<MoveNode> neighbors = new MoveNode[4];
+    while (open.TryDequeue(out var current, out _))
+    {
+        if (current.Position == goal)
+        {
+            fScores.TryGet(current.X, current.Y, out int fScore);
+            Console.WriteLine($"fScores@({current.X},{current.Y}): {fScore}");
+            return fScore;
+        }
+
+        gScores.TryGet(current.X, current.Y, out var gCurrent);
+
+        var nLength = current.GetNeighbors(in rowOrder, neighbors);
+        foreach (var n in neighbors[..nLength])
+        {
+            rowOrder.TryGetIndex(n.X, n.Y, out var nIndex);
+            var gTentative = gCurrent + 1;
+            if (gTentative < gSpan[nIndex])
+            {
+                var h = Heuristic(n.Position, in goal);
+                gSpan[nIndex] = gTentative;
+                fSpan[nIndex] = gTentative + h;
+
+                if (!open.UnorderedItems.Any(x => x.Element.Position == n.Position))
+                    open.Enqueue(n, gTentative + h);
+            }
+        }
+    }
+
+    return -1;
+}
+
+// using taxi cab distance
+static int Heuristic(in Position position, in Position goal)
+    => Math.Abs(goal.X - position.X) + Math.Abs(goal.Y - position.Y);
+
+record MoveNode(byte X, byte Y, MoveNode? Previous)
+{
+    const byte Obstacle = (byte)'#';
+    static readonly (sbyte dx, sbyte dy)[] Neighbors = [(0, -1), (0, 1), (-1, 0), (1, 0)];
+
+    public static MoveNode Start(byte x, byte y)
+        => new(x, y, Previous: null);
+
+    public MoveNode Step(sbyte dx, sbyte dy)
+        => new((byte)(X + dx), (byte)(Y + dy), Previous: this);
+
+    public Position Position => new(X, Y);
+
+    public int GetNeighbors(in RowOrderSpan<byte> rowOrder, Span<MoveNode> neighbors)
+    {
+        var length = 0;
+        foreach (var (dx, dy) in Neighbors)
+        {
+            var x = X + dx;
+            var y = Y + dy;
+            if (rowOrder.TryGet(x, y, out var cell) && cell != Obstacle)
+                neighbors[length++] = Step(dx, dy);
+        }
+
+        return length;
+    }
+}
+
+record struct Position(byte X, byte Y);


### PR DESCRIPTION
https://adventofcode.com/2024/day/18

I used A* search algorithm adapted from <https://en.wikipedia.org/wiki/A*_search_algorithm> and also viewed https://codegym.cc/groups/posts/a-search-algorithm-in-java.

I hadn't gotten to day 18 since I was exhausted after days 16 and 17. After all the other graph traversal days, I finally used a GetNeighbors method which kept the AStar method a little simpler. I used taxi cab distance for the heuristic, which is basically `abs(dx) + abs(dy)` between a position to the goal. For my A* implementation, in addition to map data and the open priority queue, there are two main arrays: gScores and fScores, where gScores are the best known scores from the start to a position, and fScores are the best known scores from start to finish through a position. In addition to the open priority queue, I used a complementary open HashSet to improve the performance of searching the open priority queue for existing positions (this improved part 2 execution time by ~5x).